### PR TITLE
Refactor editor.py to improve structure and clarity

### DIFF
--- a/src/p/display.py
+++ b/src/p/display.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk
-from components import SymbolOutlinePanel, TodoExplorerPanel
+from .components import SymbolOutlinePanel, TodoExplorerPanel
 
 class Display:
     """
@@ -9,7 +9,6 @@ class Display:
     def __init__(self, editor, master):
         """
         Initializes the Display.
-
         Args:
             editor: An instance of the HabaEditor class.
             master: The root tkinter widget.
@@ -37,6 +36,9 @@ class Display:
 
         self.lint_button = tk.Button(top_frame, text="Lint", command=self.editor.lint_script_text)
         self.lint_button.pack(side=tk.LEFT, padx=5)
+
+        self.run_button = tk.Button(top_frame, text="Run Script", command=self.editor.run_script)
+        self.run_button.pack(side=tk.LEFT, padx=5)
 
         # Main content area with three panels
         main_paned_window = tk.PanedWindow(self.master, orient=tk.VERTICAL)
@@ -73,6 +75,18 @@ class Display:
         self.todo_explorer_panel = TodoExplorerPanel(right_notebook)
         right_notebook.add(self.todo_explorer_panel, text="TODO Explorer")
 
+        # Console Output Tab
+        console_frame = tk.Frame(right_notebook)
+        self.console_output_text = tk.Text(console_frame, wrap=tk.WORD, state=tk.DISABLED)
+        self.console_output_text.pack(fill=tk.BOTH, expand=True)
+        right_notebook.add(console_frame, text="Console Output")
+
+        # Actionable Tasks Tab
+        tasks_frame = tk.Frame(right_notebook)
+        self.tasks_listbox = tk.Listbox(tasks_frame)
+        self.tasks_listbox.pack(fill=tk.BOTH, expand=True)
+        right_notebook.add(tasks_frame, text="Actionable Tasks")
+
         # Bottom panel for script editing
         script_frame = tk.Frame(main_paned_window)
         script_label = tk.Label(script_frame, text="Script Layer (.js)")
@@ -85,3 +99,7 @@ class Display:
         # Configure tags for linting
         self.script_text.tag_configure("trailing_whitespace", background="orange red")
         self.script_text.tag_configure("missing_semicolon", background="yellow")
+        self.script_text.tag_configure("use_of_var", background="#FFDDC1")
+        self.script_text.tag_configure("use_of_double_equals", background="#C1FFD7")
+        self.script_text.tag_configure("long_line", background="#E0E0E0")
+        self.script_text.tag_configure("many_parameters", background="#FFC1F5")

--- a/src/p/editor.py
+++ b/src/p/editor.py
@@ -1,62 +1,12 @@
 import tkinter as tk
-from tkinter import font as tkFont
-import re
-from haba_parser import HabaParser
-from files import FileHandler
-from display import Display
-from menu import MenuBar
 from tkinter import ttk, filedialog, font as tkFont
-from .haba_parser import HabaParser, HabaData
-from .components import SymbolOutlinePanel, TodoExplorerPanel
-from .script_runner import ScriptRunner
 import re
-
-def lint_javascript_text(script_text_widget):
-    """
-    Performs linting on the given script text widget for JavaScript code.
-    """
-    # Clear existing tags
-    for tag in ["trailing_whitespace", "missing_semicolon", "use_of_var", "use_of_double_equals", "long_line", "many_parameters"]:
-        script_text_widget.tag_remove(tag, "1.0", tk.END)
-
-    lines = script_text_widget.get("1.0", tk.END).splitlines()
-    for i, line in enumerate(lines):
-        line_num_str = f"{i + 1}"
-
-        # Check for long lines (e.g., > 80 characters)
-        if len(line) > 80:
-            script_text_widget.tag_add("long_line", f"{line_num_str}.0", f"{line_num_str}.{len(line)}")
-
-        # Check for trailing whitespace
-        match = re.search(r'(\s+)$', line)
-        if match:
-            start_pos = match.start(1)
-            script_text_widget.tag_add("trailing_whitespace", f"{line_num_str}.{start_pos}", f"{line_num_str}.{len(line)}")
-
-        # Check for `var` keyword
-        for match in re.finditer(r'\bvar\b', line):
-            script_text_widget.tag_add("use_of_var", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
-
-        # Check for `==` or `!=`
-        comment_pos = line.find('//')
-        for match in re.finditer(r'==|!=', line):
-            # If there is a comment, and the match is inside it, ignore it
-            if comment_pos != -1 and match.start() > comment_pos:
-                continue
-            script_text_widget.tag_add("use_of_double_equals", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
-        
-        # Check for functions with too many parameters (e.g., > 5)
-        match = re.search(r'function\s*\w*\s*\(([^)]*)\)', line)
-        if match:
-            params = match.group(1).split(',')
-            if len(params) > 5:
-                script_text_widget.tag_add("many_parameters", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
-
-        # Check for missing semicolon (basic heuristic)
-        stripped_line = line.strip()
-        if stripped_line and not stripped_line.startswith(("//", "/*")) and not stripped_line.endswith(("{", "}", ";", ",")):
-            script_text_widget.tag_add("missing_semicolon", f"{line_num_str}.{len(stripped_line)-1}", f"{line_num_str}.{len(stripped_line)}")
-
+from .haba_parser import HabaParser, HabaData
+from .files import FileHandler
+from .display import Display
+from .menu import MenuBar
+from .script_runner import ScriptRunner
+from .linter import lint_javascript
 
 class HabaEditor(tk.Frame):
     """
@@ -71,21 +21,16 @@ class HabaEditor(tk.Frame):
 
         # Core components
         self.parser = HabaParser()
+        self.script_runner = ScriptRunner()
 
         # Application state
         self.language = 'javascript'
         self.current_filepath = None
 
         # Modular components
-        # Note: The order of initialization can be important.
         self.file_handler = FileHandler(self)
-
-        # UI components are initialized last, as they may need to reference the handlers.
-        # Pass `self` as the master frame for the widgets.
-        self.display = Display(self, self)
+        self.display = Display(self, self) # Pass self (editor) and master frame
         self.menu_bar = MenuBar(self)
-
-    # --- Delegating Methods ---
 
     def load_file(self):
         """Delegates file loading to the FileHandler."""
@@ -94,96 +39,6 @@ class HabaEditor(tk.Frame):
     def save_file(self):
         """Delegates file saving to the FileHandler."""
         self.file_handler.save_file()
-
-    # --- Core Application Logic / Event Handlers ---
-        self.script_runner = ScriptRunner()
-        self.language = 'javascript' # Default language for the script panel
-        self.create_widgets()
-
-    def create_widgets(self):
-        # Top frame for buttons
-        top_frame = tk.Frame(self)
-        top_frame.pack(fill=tk.X, padx=5, pady=5)
-
-        self.load_button = tk.Button(top_frame, text="Load", command=self.load_file)
-        self.load_button.pack(side=tk.LEFT, padx=5)
-
-        self.save_button = tk.Button(top_frame, text="Save", command=self.save_file)
-        self.save_button.pack(side=tk.LEFT, padx=5)
-
-        self.render_button = tk.Button(top_frame, text="Render", command=self.render_preview)
-        self.render_button.pack(side=tk.LEFT, padx=5)
-
-        self.lint_button = tk.Button(top_frame, text="Lint", command=self.lint_script_text)
-        self.lint_button.pack(side=tk.LEFT, padx=5)
-
-        self.run_button = tk.Button(top_frame, text="Run Script", command=self.run_script)
-        self.run_button.pack(side=tk.LEFT, padx=5)
-
-        # Main content area with three panels
-        main_paned_window = tk.PanedWindow(self, orient=tk.VERTICAL)
-        main_paned_window.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
-
-        # Top pane with two horizontal panels for raw text and preview
-        top_paned_window = tk.PanedWindow(main_paned_window, orient=tk.HORIZONTAL)
-        main_paned_window.add(top_paned_window, stretch="always")
-
-        # Left panel for raw text editing
-        left_frame = tk.Frame(top_paned_window)
-        raw_label = tk.Label(left_frame, text="Raw .haba Text")
-        raw_label.pack(anchor=tk.W)
-        self.raw_text = tk.Text(left_frame, wrap=tk.WORD, undo=True)
-        self.raw_text.pack(fill=tk.BOTH, expand=True)
-        self.raw_text.bind("<<Modified>>", self.on_text_change)
-        top_paned_window.add(left_frame, stretch="always")
-
-        # Right panel with a notebook for different views
-        right_notebook = ttk.Notebook(top_paned_window)
-        top_paned_window.add(right_notebook, stretch="always")
-
-        # WYSIWYG Preview Tab
-        preview_frame = tk.Frame(right_notebook)
-        self.preview_text = tk.Text(preview_frame, wrap=tk.WORD, state=tk.DISABLED)
-        self.preview_text.pack(fill=tk.BOTH, expand=True)
-        right_notebook.add(preview_frame, text="WYSIWYG Preview")
-
-        # Symbol Outline Tab
-        self.symbol_outline_panel = SymbolOutlinePanel(right_notebook)
-        right_notebook.add(self.symbol_outline_panel, text="Symbol Outline")
-
-        # TODO Explorer Tab
-        self.todo_explorer_panel = TodoExplorerPanel(right_notebook)
-        right_notebook.add(self.todo_explorer_panel, text="TODO Explorer")
-
-        # Console Output Tab
-        console_frame = tk.Frame(right_notebook)
-        self.console_output_text = tk.Text(console_frame, wrap=tk.WORD, state=tk.DISABLED)
-        self.console_output_text.pack(fill=tk.BOTH, expand=True)
-        right_notebook.add(console_frame, text="Console Output")
-
-        # Actionable Tasks Tab
-        tasks_frame = tk.Frame(right_notebook)
-        self.tasks_listbox = tk.Listbox(tasks_frame)
-        self.tasks_listbox.pack(fill=tk.BOTH, expand=True)
-        right_notebook.add(tasks_frame, text="Actionable Tasks")
-
-        # Bottom panel for script editing
-        script_frame = tk.Frame(main_paned_window)
-        script_label = tk.Label(script_frame, text="Script Layer (.js)")
-        script_label.pack(anchor=tk.W)
-        self.script_text = tk.Text(script_frame, wrap=tk.WORD, undo=True)
-        self.script_text.pack(fill=tk.BOTH, expand=True)
-        self.script_text.bind("<<Modified>>", self.on_script_text_change)
-        main_paned_window.add(script_frame, stretch="always")
-
-        # Configure tags for linting
-        self.script_text.tag_configure("trailing_whitespace", background="orange red")
-        self.script_text.tag_configure("missing_semicolon", background="yellow")
-        self.script_text.tag_configure("use_of_var", background="#FFDDC1") # Light orange
-        self.script_text.tag_configure("use_of_double_equals", background="#C1FFD7") # Light green
-        self.script_text.tag_configure("long_line", background="#E0E0E0") # Light grey
-        self.script_text.tag_configure("many_parameters", background="#FFC1F5") # Light pink
-
 
     def on_text_change(self, event=None):
         self.render_preview()
@@ -199,84 +54,35 @@ class HabaEditor(tk.Frame):
         self.display.script_text.edit_modified(False)
 
     def lint_script_text(self):
-        # Clear existing tags
-        self.display.script_text.tag_remove("trailing_whitespace", "1.0", tk.END)
-        self.display.script_text.tag_remove("missing_semicolon", "1.0", tk.END)
-
-        lines = self.display.script_text.get("1.0", tk.END).splitlines()
-        for i, line in enumerate(lines):
-            line_num_str = f"{i + 1}.0"
-
-            # Check for trailing whitespace
-            if re.search(r'\s+$', line):
-                self.display.script_text.tag_add("trailing_whitespace", f"{line_num_str}", f"{line_num_str} lineend")
-
-            # Check for missing semicolon (basic heuristic)
-            stripped_line = line.strip()
-            if stripped_line and not stripped_line.startswith("//") and not stripped_line.endswith(("{", "}", ";")):
-                self.display.script_text.tag_add("missing_semicolon", f"{line_num_str}", f"{line_num_str} lineend")
-        lint_javascript_text(self.script_text)
+        """
+        Delegates linting to the lint_javascript function.
+        """
+        lint_javascript(self.display.script_text)
 
     def run_script(self):
         """
         Runs the script and updates the console and task panels.
         """
-        haba_content = self.raw_text.get("1.0", tk.END)
+        haba_content = self.display.raw_text.get("1.0", tk.END)
         
-        # To show that the process is running, you could disable the button
-        self.run_button.config(state=tk.DISABLED, text="Running...")
-        self.update()
+        self.display.run_button.config(state=tk.DISABLED, text="Running...")
+        self.master.update()
 
         logs, tasks = self.script_runner.run_script(haba_content)
 
-        # Re-enable the button
-        self.run_button.config(state=tk.NORMAL, text="Run Script")
+        self.display.run_button.config(state=tk.NORMAL, text="Run Script")
 
         # Update console output panel
-        self.console_output_text.config(state=tk.NORMAL)
-        self.console_output_text.delete("1.0", tk.END)
+        self.display.console_output_text.config(state=tk.NORMAL)
+        self.display.console_output_text.delete("1.0", tk.END)
         for log in logs:
-            self.console_output_text.insert(tk.END, f"{log}\n")
-        self.console_output_text.config(state=tk.DISABLED)
+            self.display.console_output_text.insert(tk.END, f"{log}\n")
+        self.display.console_output_text.config(state=tk.DISABLED)
 
         # Update actionable tasks panel
-        self.tasks_listbox.delete(0, tk.END)
+        self.display.tasks_listbox.delete(0, tk.END)
         for task in tasks:
-            self.tasks_listbox.insert(tk.END, f"[{task['type'].upper()}] {task['description']}")
-
-    def load_file(self):
-        filepath = filedialog.askopenfilename(
-            filetypes=[("Haba Files", "*.haba"), ("All Files", "*.*")]
-        )
-        if not filepath:
-            return
-        with open(filepath, "r") as f:
-            content = f.read()
-        self.raw_text.delete("1.0", tk.END)
-        self.raw_text.insert("1.0", content)
-        self.render_preview()
-
-    def save_file(self):
-        filepath = filedialog.asksaveasfilename(
-            defaultextension="haba",
-            filetypes=[("Haba Files", "*.haba"), ("All Files", "*.*")],
-        )
-        if not filepath:
-            return
-
-        # Parse the raw text to get the content and presentation layers
-        raw_content = self.raw_text.get("1.0", tk.END)
-        haba_data = self.parser.parse(raw_content)
-
-        # Get the script content from the script editor
-        script_content = self.script_text.get("1.0", tk.END)
-        haba_data.script = script_content.strip()
-
-        # Build the final .haba content string
-        final_content = self.parser.build(haba_data)
-
-        with open(filepath, "w") as f:
-            f.write(final_content)
+            self.display.tasks_listbox.insert(tk.END, f"[{task['type'].upper()}] {task['description']}")
 
     def _apply_styles(self, style_str, tag_name):
         """
@@ -294,7 +100,7 @@ class HabaEditor(tk.Frame):
                     font.configure(size=size)
                     options['font'] = font
                 except ValueError:
-                    pass # Ignore invalid font sizes
+                    pass
         self.display.preview_text.tag_configure(tag_name, **options)
 
     def render_preview(self):
@@ -302,7 +108,6 @@ class HabaEditor(tk.Frame):
         try:
             haba_data = self.parser.parse(raw_content)
         except Exception as e:
-            # If parsing fails, show error in preview
             self.display.preview_text.config(state=tk.NORMAL)
             self.display.preview_text.delete('1.0', tk.END)
             self.display.preview_text.insert('1.0', f"Error parsing .haba file:\n{e}")
@@ -325,7 +130,6 @@ class HabaEditor(tk.Frame):
 
         self.display.preview_text.config(state=tk.DISABLED)
 
-        # Update script text editor and explorer panels
         self.display.script_text.delete("1.0", tk.END)
         self.display.script_text.insert("1.0", haba_data.script)
         self.on_script_text_change()

--- a/src/p/linter.py
+++ b/src/p/linter.py
@@ -1,0 +1,47 @@
+import re
+import tkinter as tk
+
+def lint_javascript(script_text_widget):
+    """
+    Performs linting on the script text widget for JavaScript code.
+    """
+    # Clear existing tags
+    for tag in ["trailing_whitespace", "missing_semicolon", "use_of_var", "use_of_double_equals", "long_line", "many_parameters"]:
+        script_text_widget.tag_remove(tag, "1.0", tk.END)
+
+    lines = script_text_widget.get("1.0", tk.END).splitlines()
+    for i, line in enumerate(lines):
+        line_num_str = f"{i + 1}"
+
+        # Check for long lines (e.g., > 80 characters)
+        if len(line) > 80:
+            script_text_widget.tag_add("long_line", f"{line_num_str}.0", f"{line_num_str}.{len(line)}")
+
+        # Check for trailing whitespace
+        match = re.search(r'(\s+)$', line)
+        if match:
+            start_pos = match.start(1)
+            script_text_widget.tag_add("trailing_whitespace", f"{line_num_str}.{start_pos}", f"{line_num_str}.{len(line)}")
+
+        # Check for `var` keyword
+        for match in re.finditer(r'\bvar\b', line):
+            script_text_widget.tag_add("use_of_var", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
+
+        # Check for `==` or `!=`
+        comment_pos = line.find('//')
+        for match in re.finditer(r'==|!=', line):
+            if comment_pos != -1 and match.start() > comment_pos:
+                continue
+            script_text_widget.tag_add("use_of_double_equals", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
+
+        # Check for functions with too many parameters (e.g., > 5)
+        match = re.search(r'function\s*\w*\s*\(([^)]*)\)', line)
+        if match:
+            params = match.group(1).split(',')
+            if len(params) > 5:
+                script_text_widget.tag_add("many_parameters", f"{line_num_str}.{match.start()}", f"{line_num_str}.{match.end()}")
+
+        # Check for missing semicolon (basic heuristic)
+        stripped_line = line.strip()
+        if stripped_line and not stripped_line.startswith(("//", "/*")) and not stripped_line.endswith(("{", "}", ";", ",")):
+            script_text_widget.tag_add("missing_semicolon", f"{line_num_str}.{len(stripped_line)-1}", f"{line_num_str}.{len(stripped_line)}")

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -12,7 +12,7 @@ sys.modules['tkinter.filedialog'] = MagicMock()
 sys.modules['tkinter.font'] = MagicMock()
 
 # Now that tkinter is mocked, we can safely import the linter function
-from src.p.editor import lint_javascript_text
+from src.p.linter import lint_javascript
 
 class TestLinter(unittest.TestCase):
     
@@ -35,7 +35,7 @@ class TestLinter(unittest.TestCase):
         script_text_mock.get.return_value = test_script
         
         # Call the linting function directly, passing the mock widget
-        lint_javascript_text(script_text_mock)
+        lint_javascript(script_text_mock)
 
         # Get the list of calls to tag_add
         calls = script_text_mock.tag_add.call_args_list


### PR DESCRIPTION
The editor.py module was the result of a bad merge, containing duplicated code and poor structure. This change refactors the module to correctly delegate responsibilities to its components.

- The linting logic has been extracted into a new `linter.py` module for better separation of concerns and testability.
- The UI creation logic has been removed from `editor.py` and is now fully handled by `display.py`.
- The `HabaEditor` class has been cleaned up to act as a controller, delegating tasks to its components and preserving all original functionality.
- The linter test has been updated to reflect the new structure.