### PR TITLE
feat: Integrate Quanta Haba demo via Python package

### DIFF
--- a/src/p/default_prompt.txt
+++ b/src/p/default_prompt.txt
@@ -1,0 +1,3 @@
+TODO: Generate project title
+TODO: Suggest 3 features
+TODO: Write short summary

--- a/src/p/requirements.txt
+++ b/src/p/requirements.txt
@@ -1,0 +1,2 @@
+-e git+https://github.com/drtamarojgreen/quanta_tissu
+numpy


### PR DESCRIPTION
This commit refactors the Quanta Haba demo integration to use the `quanta_tissu` Python package directly, replacing the previous REST API implementation.

The demo is encapsulated in a `QuantaDemoWindow` Toplevel window and is launched from a button in the main editor, ensuring no existing functionality is removed.

The new implementation initializes the tokenizer and model from the `quanta_tissu` package, using placeholder paths for the required artifacts. It includes robust error handling for cases where the package or model files are not found, falling back to stubbed responses.

The `requirements.txt` file has been updated to include the `quanta_tissu` git dependency and `numpy`.