### PR TITLE
feat: Create demo video script

### DIFF
--- a/docs/demo_video_script.md
+++ b/docs/demo_video_script.md
@@ -1,0 +1,125 @@
+# QuantaHaba Demo Video Script
+---
+
+## 1. Introduction
+
+**SCENE START**
+
+**VISUAL:**
+A clean, minimalist title card appears. The text "QuantaHaba" is centered, with a small, stylized leaf icon (🌱) next to it. The tagline "A Safe Habitat for Ideas to Grow" fades in below.
+
+**VOICEOVER:**
+*(Upbeat, inspiring tech-style music begins)*
+
+"In the world of web design, creativity and structure often feel like they're at odds. But what if they weren't?
+
+"Introducing QuantaHaba, an LLM-powered design editor that's rethinking how we build interactive web experiences. Imagine the creative freedom of Figma, the powerful backend logic of Wix Velo, and the intelligence of a next-generation AI, all working in harmony."
+
+**VISUAL:**
+The title card fades out, replaced by a quick montage of abstract, beautiful UI components being assembled on a clean grid.
+
+**VOICEOVER:**
+"QuantaHaba is built on the concept of 'Design Habitats'—safe, structured spaces where you can experiment with code, components, and new ideas without the fear of breaking anything. It's a place for your ideas to grow."
+
+**SCENE END**
+
+---
+
+## 2. The Demo: Under the Hood
+
+**SCENE START**
+
+**VISUAL:**
+The abstract visuals fade away, and we see a screen recording of the QuantaHaba Demo application. It's a clean, developer-focused interface with three distinct panels. The left and right panels are mostly empty, and the bottom panel shows some initial startup text.
+
+**VOICEOVER:**
+"But powerful ideas need a solid foundation. Before building a full-featured visual editor, we need to ensure the core AI engine is robust, transparent, and reliable.
+
+"And that's what this demo is all about. This isn't the final user-facing editor, but a look under the hood at the engine that powers QuantaHaba."
+
+**VISUAL:**
+As the voiceover mentions each panel, it gets highlighted with a soft-colored overlay.
+1.  Left panel is highlighted. Text "Prompt Editor" appears.
+2.  Right panel is highlighted. Text "Model Responses" appears.
+3.  Bottom panel is highlighted. Text "Console Log" appears.
+
+**VOICEOVER:**
+"What you're seeing is our core AI workflow, broken down into three parts.
+
+"On the left, we have the **Prompt Editor**, where we feed a set of tasks to the AI.
+"On the right, the **Model Responses** panel, where the AI's output will appear in real-time.
+"And at the bottom, the **Console Log**, giving us a transparent, play-by-play of everything happening in the background."
+
+**SCENE END**
+
+---
+
+## 3. The Workflow in Action
+
+**SCENE START**
+
+### PART A: THE "BEFORE"
+
+**VISUAL:**
+Zoom in on the left panel, the **Prompt Editor**. The content of `default_prompt.txt` is now visible, showing a list of tasks, each prefixed with "TODO:".
+
+**VOICEOVER:**
+"Let's see it in action. We start with the prompt. This is a simple text file with a list of instructions for our AI. Each 'TODO' item represents a task we want the model to perform, like generating code, writing documentation, or creating a list."
+
+### PART B: THE "DURING"
+
+**VISUAL:**
+The demo springs to life.
+- In the left panel, the "TODO:" next to the first task highlights, then changes to a green "DONE:".
+- Simultaneously, the right panel, **Model Responses**, populates with the first task and a formatted block containing the AI's response.
+- The bottom **Console Log** panel scrolls rapidly, showing logs for model initialization, task processing, and text generation.
+This process repeats down the list of tasks automatically. The visuals should be sped up slightly to keep the pace engaging.
+
+**VOICEOVER:**
+"Now, we run the demo. Watch closely.
+
+"The application automatically reads each task. For each one, it calls our core AI engine—a sophisticated text-generation model we call 'QuantaTissu'. This model is running locally, demonstrating how the core logic can be integrated directly into a Python application.
+
+"You can see the 'TODOs' turning to 'DONEs' as the AI completes its work. The console log shows us every step, from loading the model weights to generating the response tokens. This transparency is key for developers who will build on this platform."
+
+### PART C: THE "AFTER"
+
+**VISUAL:**
+The demo finishes, with all tasks marked "DONE". The shot now focuses on the **Model Responses** panel, which is filled with a neatly organized list of tasks and their corresponding AI-generated outputs. We see status icons (✓) next to each completed task.
+
+**VOICEOVER:**
+"And here are the results. In just a few moments, the AI has completed the entire workflow.
+
+"The right panel gives us a clean, organized record of the outputs. This demonstrates a key feature: structured, reliable responses from the model. It's not just a chatbot; it's a task-completion engine.
+
+"This entire automated process—from prompt, to processing, to a structured output—is the foundational loop that will power all the user-facing features in the final QuantaHaba editor."
+
+**SCENE END**
+
+---
+
+## 4. Strategy and Conclusion
+
+**SCENE START**
+
+**VISUAL:**
+A wide shot of the completed demo application. Text overlays appear on screen, summarizing the key strategic points: "Prove the Core Engine First," "Ensure Transparency & Reliability," "Build a Foundation for the Future."
+
+**VOICEOVER:**
+"So, what does this demo tell us? It reveals our strategy.
+
+"Instead of jumping straight to a complex visual interface, we started with the most critical part: the engine. By building and testing this core workflow, we're proving that the AI is not just a concept, but a functional, reliable tool that can execute complex tasks.
+
+"This 'engine-first' approach ensures that when we build the beautiful QuantaHaba design editor, it will have a powerful and transparent foundation to stand on."
+
+**VISUAL:**
+The demo application fades out, replaced by the final title card, similar to the intro. This time, it shows the QuantaHaba logo and text that says "The Future is Growing." A few key future features from the roadmap (e.g., "Visual Design Canvas," "AI Pair Designer," "Plugin Marketplace") appear briefly on screen.
+
+**VOICEOVER:**
+"What you've seen today is the heartbeat of QuantaHaba. The next step is to build the body around it—a full-featured, collaborative design canvas with an AI pair designer that brings the power of this engine to creators everywhere.
+
+"The habitat is ready. The future of web design is about to bloom."
+
+*(Music swells and fades out)*
+
+**SCENE END**


### PR DESCRIPTION
Creates a detailed video script in `docs/demo_video_script.md` to explain the QuantaHaba demo.

The script covers the project's features, implementation details, and the strategy behind the demo, drawing from existing documentation.

The script is structured for a video production, including visual cues and voiceover text, to clearly communicate the purpose and functionality of the core AI engine demo.