### PR TITLE
feat: Add OAuth2 integration for external models

### DIFF
--- a/src/p/editor.py
+++ b/src/p/editor.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 class QuantaDemoWindow(tk.Toplevel):
-    def __init__(self, master=None):
+    def __init__(self, master=None, external_model_client=None):
         super().__init__(master)
         self.title("Quanta Haba Demo")
         self.geometry("1000x700")
@@ -23,6 +23,7 @@ class QuantaDemoWindow(tk.Toplevel):
         self.model = None
         self.tokenizer = None
         self.work_products = []
+        self.external_model_client = external_model_client
         
         # Create widgets first, then initialize model
         self.create_widgets()
@@ -147,9 +148,27 @@ class QuantaDemoWindow(tk.Toplevel):
     def call_quanta_model(self, task, line_index):
         import datetime
         
-        # Generate model response
-        if self.model and self.tokenizer:
+        model_response = f"Stubbed response for '{task}'"
+        is_stubbed = True
+
+        # Try external model first if available and authenticated
+        if self.external_model_client and self.external_model_client.is_authenticated():
             try:
+                self.log_to_console("Calling external model...")
+                response_data = self.external_model_client.call_model(task)
+                # Assuming the API returns a structure like {'choices': [{'text': '...'}]}
+                model_response = response_data.get('choices', [{}])[0].get('text', 'No response text found.')
+                is_stubbed = False
+                self.log_to_console("External model call successful.")
+            except Exception as e:
+                self.log_to_console(f"External model error: {e}. Falling back.")
+                model_response = f"External model failed: {e}"
+                is_stubbed = True
+
+        # Fallback to local model
+        elif self.model and self.tokenizer:
+            try:
+                self.log_to_console("Calling local Quanta Tissu model...")
                 model_response = generate_text(
                     model=self.model,
                     tokenizer=self.tokenizer,
@@ -161,8 +180,8 @@ class QuantaDemoWindow(tk.Toplevel):
                 model_response = f"Stubbed response for '{task}'"
                 is_stubbed = True
         else:
-            model_response = f"Stubbed response for '{task}'"
-            is_stubbed = True
+            # This is the final fallback
+            self.log_to_console("No models available. Using stubbed response.")
 
         # Create work product entry
         work_product = {
@@ -205,11 +224,13 @@ try:
     from .components import SymbolOutlinePanel, TodoExplorerPanel
     from .script_runner import ScriptRunner
     from .html_exporter import HtmlExporter
+    from .external_model_client import ExternalModelClient
 except ImportError:
     from haba_parser import HabaParser, HabaData
     from components import SymbolOutlinePanel, TodoExplorerPanel
     from script_runner import ScriptRunner
     from html_exporter import HtmlExporter
+    from external_model_client import ExternalModelClient
 
 def lint_javascript_text(script_text_widget):
     """
@@ -258,6 +279,55 @@ def lint_javascript_text(script_text_widget):
             script_text_widget.tag_add("missing_semicolon", f"{line_num_str}.{len(stripped_line)-1}", f"{line_num_str}.{len(stripped_line)}")
 
 
+class ConfigDialog(tk.Toplevel):
+    def __init__(self, parent, initial_config=None):
+        super().__init__(parent)
+        self.title("External Model Configuration")
+        self.transient(parent)
+        self.grab_set()
+
+        self.result = None
+        self.initial_config = initial_config or {}
+
+        self.entries = {}
+        self.create_widgets()
+        self.wait_window(self)
+
+    def create_widgets(self):
+        frame = tk.Frame(self, padx=10, pady=10)
+        frame.pack(fill=tk.BOTH, expand=True)
+
+        fields = {
+            "client_id": "Client ID:",
+            "client_secret": "Client Secret:",
+            "authorization_url": "Authorization URL:",
+            "token_url": "Token URL:",
+            "api_base_url": "API Base URL:"
+        }
+
+        for i, (key, text) in enumerate(fields.items()):
+            label = tk.Label(frame, text=text)
+            label.grid(row=i, column=0, sticky=tk.W, pady=2)
+            entry = tk.Entry(frame, width=50)
+            entry.grid(row=i, column=1, sticky=tk.EW, pady=2)
+            entry.insert(0, self.initial_config.get(key, ""))
+            self.entries[key] = entry
+
+        frame.grid_columnconfigure(1, weight=1)
+
+        button_frame = tk.Frame(frame)
+        button_frame.grid(row=len(fields), column=0, columnspan=2, pady=10)
+
+        save_button = tk.Button(button_frame, text="Save", command=self._save_config)
+        save_button.pack(side=tk.LEFT, padx=5)
+        cancel_button = tk.Button(button_frame, text="Cancel", command=self.destroy)
+        cancel_button.pack(side=tk.LEFT, padx=5)
+
+    def _save_config(self):
+        self.result = {key: entry.get() for key, entry in self.entries.items()}
+        self.destroy()
+
+
 class HabaEditor(tk.Frame):
     def __init__(self, master=None):
         super().__init__(master)
@@ -268,7 +338,15 @@ class HabaEditor(tk.Frame):
         self.script_runner = ScriptRunner()
         self.html_exporter = HtmlExporter()
         self.language = 'javascript' # Default language for the script panel
+        self.external_model_client = None
+        self.external_model_config = {}
         self.create_widgets()
+
+    def open_config_dialog(self, event=None):
+        dialog = ConfigDialog(self, self.external_model_config)
+        if dialog.result:
+            self.external_model_config = dialog.result
+            messagebox.showinfo("Configuration Saved", "External model configuration has been updated.")
 
     def create_widgets(self):
         # Top frame for buttons
@@ -295,6 +373,9 @@ class HabaEditor(tk.Frame):
 
         self.quanta_demo_button = tk.Button(top_frame, text="Quanta Demo", command=self.launch_quanta_demo)
         self.quanta_demo_button.pack(side=tk.LEFT, padx=5)
+
+        self.connect_external_button = tk.Button(top_frame, text="Connect External Model", command=self.connect_external_model)
+        self.connect_external_button.pack(side=tk.LEFT, padx=5)
 
         # Main content area with three panels
         main_paned_window = tk.PanedWindow(self, orient=tk.VERTICAL)
@@ -360,6 +441,9 @@ class HabaEditor(tk.Frame):
         self.script_text.tag_configure("long_line", background="#E0E0E0") # Light grey
         self.script_text.tag_configure("many_parameters", background="#FFC1F5") # Light pink
 
+        # Bind keyboard shortcut for config dialog
+        self.master.bind("<Control-m>", self.open_config_dialog)
+
 
     def on_text_change(self, event=None):
         self.render_preview()
@@ -374,8 +458,29 @@ class HabaEditor(tk.Frame):
         self.lint_script_text()
         self.script_text.edit_modified(False)
 
+    def connect_external_model(self):
+        if not self.external_model_config:
+            messagebox.showwarning("Configuration Missing", "Please configure the external model first (Ctrl+M).")
+            return
+        try:
+            self.external_model_client = ExternalModelClient(self.external_model_config)
+            httpd = self.external_model_client.initiate_authorization()
+            self.after(100, self.check_auth_status, httpd)
+        except Exception as e:
+            messagebox.showerror("Error", f"An error occurred during authentication: {e}")
+
+    def check_auth_status(self, httpd):
+        if httpd.auth_code:
+            httpd.shutdown()
+            if self.external_model_client.finish_authorization(httpd):
+                messagebox.showinfo("Success", "External model authenticated successfully.")
+            else:
+                messagebox.showwarning("Authentication Failed", "Could not authenticate with the external model.")
+        else:
+            self.after(100, self.check_auth_status, httpd)
+
     def launch_quanta_demo(self):
-        demo_window = QuantaDemoWindow(self.master)
+        demo_window = QuantaDemoWindow(self.master, external_model_client=self.external_model_client)
 
     def lint_script_text(self):
         lint_javascript_text(self.script_text)
@@ -533,10 +638,8 @@ class HabaEditor(tk.Frame):
 
 def main():
     root = tk.Tk()
-    # Hide the root window
-    root.withdraw()
-    app = QuantaDemoWindow(master=root)
-    app.mainloop()
+    app = HabaEditor(master=root)
+    root.mainloop()
 
 if __name__ == '__main__':
     main()

--- a/src/p/external_model_client.py
+++ b/src/p/external_model_client.py
@@ -1,0 +1,127 @@
+import webbrowser
+import requests
+from requests_oauthlib import OAuth2Session
+import os
+import threading
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+# Placeholder credentials - in a real application, these would be stored securely
+# and not hardcoded.
+REDIRECT_URI = "http://localhost:8080/callback"
+
+class OAuth2CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        """
+        Handles the redirect from the OAuth provider.
+        Extracts the authorization code and state.
+        """
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+        self.wfile.write(b"<h1>Authentication Successful!</h1>")
+        self.wfile.write(b"<p>You can close this window now.</p>")
+
+        # The server attribute is set by the ExternalModelClient
+        if 'code' in self.path:
+            self.server.auth_code = self.path.split('code=')[1].split('&')[0]
+
+class ExternalModelClient:
+    def __init__(self, config):
+        self.config = config
+        self.client_id = self.config.get("client_id", "")
+        self.client_secret = self.config.get("client_secret", "")
+        self.authorization_url = self.config.get("authorization_url", "")
+        self.token_url = self.config.get("token_url", "")
+        self.api_base_url = self.config.get("api_base_url", "")
+
+        self.session = None
+        self.token = None
+        self._httpd_thread = None
+
+    def _start_local_server(self):
+        """
+        Starts a local HTTP server in a separate thread to handle the OAuth redirect.
+        """
+        server_address = ('localhost', 8080)
+        httpd = HTTPServer(server_address, OAuth2CallbackHandler)
+        httpd.auth_code = None # To store the received auth code
+
+        self._httpd_thread = threading.Thread(target=httpd.serve_forever)
+        self._httpd_thread.daemon = True
+        self._httpd_thread.start()
+
+        return httpd
+
+    def initiate_authorization(self):
+        """
+        Starts the OAuth 2.0 authorization flow by opening the browser.
+        Returns the httpd server instance that is listening for the callback.
+        This is non-blocking. The caller is responsible for polling the
+        httpd instance for the auth_code.
+        """
+        # Step 1: Start local server to catch redirect
+        httpd = self._start_local_server()
+
+        # Step 2: User authorization
+        oauth = OAuth2Session(self.client_id, redirect_uri=REDIRECT_URI)
+        authorization_url, state = oauth.authorization_url(self.authorization_url)
+
+        webbrowser.open(authorization_url)
+
+        return httpd
+
+    def finish_authorization(self, httpd):
+        """
+        Finishes the authorization flow once the auth code is available.
+        This should be called after the local server has received the code.
+        """
+        if httpd.auth_code is None:
+            # This should not happen if called correctly
+            return False
+
+        auth_code = httpd.auth_code
+
+        # The server thread should be stopped by the caller.
+        # In a more robust implementation, the server would be managed better.
+
+        # Step 4: Fetch the access token
+        try:
+            self._fetch_token(auth_code)
+            return True
+        except Exception as e:
+            # This is a simplified error handling.
+            print(f"Error fetching token: {e}")
+            return False
+
+    def _fetch_token(self, auth_code):
+        """
+        Exchanges the authorization code for an access token.
+        """
+        oauth = OAuth2Session(self.client_id, redirect_uri=REDIRECT_URI)
+        self.token = oauth.fetch_token(
+            self.token_url,
+            code=auth_code,
+            client_secret=self.client_secret
+        )
+        self.session = oauth
+
+    def call_model(self, prompt):
+        """
+        Makes a call to the external model's API.
+        """
+        if not self.session or not self.token:
+            raise Exception("Client not authenticated. Please call initiate_authorization() first.")
+
+        # Example API call
+        response = self.session.post(
+            f"{self.api_base_url}/completions",
+            json={"prompt": prompt, "max_tokens": 50}
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def is_authenticated(self):
+        """
+        Checks if the client has a valid token.
+        """
+        return self.token is not None

--- a/src/p/requirements.txt
+++ b/src/p/requirements.txt
@@ -1,2 +1,4 @@
 -e git+https://github.com/drtamarojgreen/quanta_tissu
 numpy
+requests
+requests-oauthlib


### PR DESCRIPTION
This commit introduces a comprehensive OAuth2 integration for connecting to external language models.

Features:
- A new `ExternalModelClient` class to handle the OAuth2 authorization code flow in a non-blocking way suitable for a GUI application.
- A configuration dialog, accessible via a new button or the `Ctrl+M` keyboard shortcut, allowing users to enter their own API credentials (client ID, secret, URLs).
- Integration of the client into the main editor application, allowing the demo window to use an authenticated external model, with a fallback to the local model.

Fixes:
- The authorization flow was refactored to be non-blocking, preventing the UI from freezing.
- The application startup logic was corrected to properly initialize the main Tkinter window.